### PR TITLE
fix: Remove unused dev dependency @esbuild/darwin-arm64

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "license": "MIT",
   "devDependencies": {
     "@electron/notarize": "^3.0.1",
-    "@esbuild/darwin-arm64": "^0.25.5",
     "@eslint/js": "^9.25.0",
     "@tailwindcss/vite": "^4.1.10",
     "@types/react": "^19.1.2",


### PR DESCRIPTION
Works fine on Linux Mint. Sorry, don't have a Mac to test with to make sure there are no side-effects on that platform